### PR TITLE
Remove warning unknown configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,17 +27,28 @@
   ],
   "main": "./out/src/extension",
   "contributes": {
-    "commands": [
-      {
-        "command": "ShowCoverage",
-        "title": "Show Code Coverage"
-      },
-      {
-        "command": "HideCoverage",
-        "title": "Hide Code Coverage"
-      }
-    ]
-  },
+		"commands": [
+			{
+				"command": "ShowCoverage",
+				"title": "Show Code Coverage"
+			},
+			{
+				"command": "HideCoverage",
+				"title": "Hide Code Coverage"
+			}
+		],
+    "configuration": {
+        "type": "object",
+        "title": "bma-coverage extension",
+        "properties": {
+            "bma-coverage": {
+                "type": "object",
+                "default": "",
+                "description": "Add Path to lcov.info"
+            }
+        }
+    }
+	},
   "scripts": {
     "vscode:prepublish": "tsc -p ./",
     "compile": "tsc -watch -p ./",


### PR DESCRIPTION
In order to remove the warning "unknown configuration setting" when adding  an entry (bma-coverage) in workspace settings